### PR TITLE
fix: JWT_TOKEN environment variable to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,4 @@ jobs:
         HD_GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
         HD_GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
         HD_GOOGLE_OAUTH_REDIRECT_URI: ${{ secrets.GOOGLE_OAUTH_REDIRECT_URI }}
+        HD_JWT_SECRET: ${{ secrets.JWT_TOKEN }}


### PR DESCRIPTION
should be done in Heroku instead